### PR TITLE
 Asynchonously make Comprehend requests per chunk 

### DIFF
--- a/internal/get_content_analysis.go
+++ b/internal/get_content_analysis.go
@@ -119,7 +119,7 @@ func GetContentAnalysisForPath(path string, capiKey string) (*models.ContentAnal
 		return nil, errors.Wrap(err, "Couldn't get article fields from CAPI for given path")
 	}
 
-	entities, err := services.GetEntitiesFromPath(path)
+	entities, err := services.GetEntitiesFromPath(path, articleFields)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "Couldn't get entities for given path")

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -44,6 +44,7 @@ type Person struct {
 	Gender Gender
 }
 
+//Note - entity offsets may not be accurate for articles longer than 5000 chars
 type ContentAnalysis struct {
 	Path               string               `json:"path"`
 	Headline           string               `json:"headline"`

--- a/internal/services/comprehend.go
+++ b/internal/services/comprehend.go
@@ -31,6 +31,7 @@ func IsLetter(char uint8) bool {
     return unicode.IsLetter(rune(char))
 }
 
+//TODO - this function could be simpler if the aws sdk allows us to asynchronously process text in chunks?
 func GetEntitiesFromBodyText(bodyText string) ([]*comprehend.Entity, error) {
     client, err := GetComprehendClient("developerPlayground")
 

--- a/internal/services/comprehend.go
+++ b/internal/services/comprehend.go
@@ -40,18 +40,18 @@ func GetEntitiesFromBodyText(bodyText string) ([]*comprehend.Entity, error) {
     for i := 0; i < len(bodyText); {
         var end = i + ComprehendMaxChars-1
 
-		if end >= len(bodyText) {
-			//final chunk
-			end = len(bodyText)-1
-		} else if bodyText[end] != ' ' {
-			//Avoid splitting on a word
-			for j := end - 1; j >= i; j-- {
-				if bodyText[j] == ' ' {
-					end = j
-					break
-				}
-			}
-		}
+        if end >= len(bodyText) {
+            //final chunk
+            end = len(bodyText)-1
+        } else if bodyText[end] != ' ' {
+            //Avoid splitting on a word
+            for j := end - 1; j >= i; j-- {
+                if bodyText[j] == ' ' {
+                    end = j
+                    break
+                }
+            }
+        }
 
         var chunk = bodyText[i:end]
 

--- a/internal/services/comprehend.go
+++ b/internal/services/comprehend.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+    "article-content-analysis/internal/models"
     "fmt"
     "github.com/aws/aws-sdk-go/service/comprehend"
     "github.com/pkg/errors"
@@ -90,12 +91,7 @@ func GetEntitiesFromBodyText(bodyText string) ([]*comprehend.Entity, error) {
     return results, nil
 }
 
-func GetEntitiesFromPath(path string) ([]*comprehend.Entity, error) {
-    articleFields, err := GetArticleFieldsFromCapi(path, "test")
-    if err != nil {
-        return nil, errors.Wrap(err, "Couldn't get article fields from CAPI for given path")
-    }
-
+func GetEntitiesFromPath(path string, articleFields *models.Content) ([]*comprehend.Entity, error) {
     entities, err := GetEntitiesFromBodyText(articleFields.Fields.BodyText)
 
     if err != nil {

--- a/internal/services/comprehend.go
+++ b/internal/services/comprehend.go
@@ -1,94 +1,89 @@
 package services
 
 import (
-	"fmt"
-	"github.com/aws/aws-sdk-go/service/comprehend"
-	"github.com/pkg/errors"
-	"math"
-	"sync"
+    "fmt"
+    "github.com/aws/aws-sdk-go/service/comprehend"
+    "github.com/pkg/errors"
+    "math"
+    "sync"
 )
 
 func GetComprehendClient(profile string) (*comprehend.Comprehend, error) {
-	sess, err := GetAwsSession(profile, "eu-west-1")
+    sess, err := GetAwsSession(profile, "eu-west-1")
 
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to create new sessions")
-	}
+    if err != nil {
+        return nil, errors.Wrap(err, "unable to create new sessions")
+    }
 
-	return comprehend.New(sess), nil
+    return comprehend.New(sess), nil
 }
 
 type ComprehendResult struct {
-	Result *comprehend.DetectEntitiesOutput
-	Error error
+    Result *comprehend.DetectEntitiesOutput
+    Error error
 }
 
 const ComprehendMaxChars = 5000
 
 func GetEntitiesFromBodyText(bodyText string) ([]*comprehend.Entity, error) {
-	client, err := GetComprehendClient("developerPlayground")
+    client, err := GetComprehendClient("developerPlayground")
 
-	if err != nil {
-		return nil, errors.Wrap(err, "couldn't create client")
-	}
+    if err != nil {
+        return nil, errors.Wrap(err, "couldn't create client")
+    }
 
-	// Use a separate goroutine to request each chunk, and wait for each to write to the channel
-	comprehendResults := make(chan ComprehendResult)
-	var wg sync.WaitGroup
-	wg.Add(int(math.Ceil( float64(len(bodyText)) / float64(ComprehendMaxChars) )))
+    // Use a separate goroutine to request each chunk, and wait for each to write to the channel
+    comprehendResults := make(chan ComprehendResult)
+    var wg sync.WaitGroup
+    wg.Add(int(math.Ceil( float64(len(bodyText)) / float64(ComprehendMaxChars) )))
 
-	for i := 0; i < len(bodyText); i += ComprehendMaxChars {
-		//TODO - avoiding splitting on words
-		var end = i + ComprehendMaxChars-1
-		if end >= len(bodyText) {
-			end = len(bodyText)-1
-		}
-		var chunk = bodyText[i:end]
+    for i := 0; i < len(bodyText); i += ComprehendMaxChars {
+        //TODO - avoiding splitting on words
+        var end = i + ComprehendMaxChars-1
+        if end >= len(bodyText) {
+            end = len(bodyText)-1
+        }
+        var chunk = bodyText[i:end]
 
-		go func(text string) {
-			defer wg.Done()
+        go func(text string) {
+            defer wg.Done()
 
-			input := &comprehend.DetectEntitiesInput{}
-			input.SetText(text)
-			input.SetLanguageCode("en")
-			result, err := client.DetectEntities(input)
-			if err != nil {
-				fmt.Println("Comprehend request error", err)
-			}
+            input := &comprehend.DetectEntitiesInput{}
+            input.SetText(text)
+            input.SetLanguageCode("en")
+            result, err := client.DetectEntities(input)
+            if err != nil {
+                fmt.Println("Comprehend request error", err)
+            }
 
-			comprehendResults <- ComprehendResult{result, err}
-		}(chunk)
-	}
+            comprehendResults <- ComprehendResult{result, err}
+        }(chunk)
+    }
 
-	go func() {
-		wg.Wait()
-		close(comprehendResults)
-	}()
+    go func() {
+        wg.Wait()
+        close(comprehendResults)
+    }()
 
-	results := make([]*comprehend.Entity, 0)
-	for response := range comprehendResults {
-		results = append(results, response.Result.Entities...)
-	}
+    results := make([]*comprehend.Entity, 0)
+    for response := range comprehendResults {
+        results = append(results, response.Result.Entities...)
+    }
 
-	return results, nil
+    return results, nil
 }
 
 func GetEntitiesFromPath(path string) ([]*comprehend.Entity, error) {
-	articleFields, err := GetArticleFieldsFromCapi(path, "test")
-	if err != nil {
-		return nil, errors.Wrap(err, "Couldn't get article fields from CAPI for given path")
-	}
-	var bodyText = articleFields.Fields.BodyText
+    articleFields, err := GetArticleFieldsFromCapi(path, "test")
+    if err != nil {
+        return nil, errors.Wrap(err, "Couldn't get article fields from CAPI for given path")
+    }
 
-	// hack to stop it failing on long articles
-	if len(bodyText) > 4999 {
-		bodyText = articleFields.Fields.BodyText[0:4999]
-	}
-	entities, err := GetEntitiesFromBodyText(bodyText)
+    entities, err := GetEntitiesFromBodyText(articleFields.Fields.BodyText)
 
-	if err != nil {
-		return nil, errors.Wrap(err, "Error retrieving entities from body text")
-	}
+    if err != nil {
+        return nil, errors.Wrap(err, "Error retrieving entities from body text")
+    }
 
-	return entities, nil
+    return entities, nil
 }

--- a/internal/services/comprehend.go
+++ b/internal/services/comprehend.go
@@ -6,6 +6,7 @@ import (
     "github.com/pkg/errors"
     "math"
     "sync"
+    "unicode"
 )
 
 func GetComprehendClient(profile string) (*comprehend.Comprehend, error) {
@@ -25,6 +26,10 @@ type ComprehendResult struct {
 
 const ComprehendMaxChars = 5000
 
+func IsLetter(char uint8) bool {
+    return unicode.IsLetter(rune(char))
+}
+
 func GetEntitiesFromBodyText(bodyText string) ([]*comprehend.Entity, error) {
     client, err := GetComprehendClient("developerPlayground")
 
@@ -43,10 +48,10 @@ func GetEntitiesFromBodyText(bodyText string) ([]*comprehend.Entity, error) {
         if end >= len(bodyText) {
             //final chunk
             end = len(bodyText)-1
-        } else if bodyText[end] != ' ' {
+        } else if IsLetter(bodyText[end]) {
             //Avoid splitting on a word
             for j := end - 1; j >= i; j-- {
-                if bodyText[j] == ' ' {
+                if !IsLetter(bodyText[j]) {
                     end = j
                     break
                 }

--- a/internal/services/comprehend_test.go
+++ b/internal/services/comprehend_test.go
@@ -1,18 +1,18 @@
 package services
 
 import (
-	"fmt"
-	"testing"
+    "fmt"
+    "testing"
 )
 
 func TestGetEntitiesFromPath(t *testing.T) {
-	res, err := GetEntitiesFromPath("/uk-news/2019/apr/11/julian-assange-arrested-at-ecuadorian-embassy-wikileaks")
+    res, err := GetEntitiesFromPath("/uk-news/2019/apr/11/julian-assange-arrested-at-ecuadorian-embassy-wikileaks")
 
-	if err != nil {
-		t.Error(err)
-	} else {
-		for _, entity := range res {
-			fmt.Println(entity.GoString())
-		}
-	}
+    if err != nil {
+        t.Error(err)
+    } else {
+        for _, entity := range res {
+            fmt.Println(entity.GoString())
+        }
+    }
 }

--- a/internal/services/comprehend_test.go
+++ b/internal/services/comprehend_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestGetEntitiesFromPath(t *testing.T) {
-	res, err := GetEntitiesFromPath("/artanddesign/2019/feb/21/from-hepworth-to-rodin-uk-sculpture-collection-to-be-catalogued-online")
+	res, err := GetEntitiesFromPath("/uk-news/2019/apr/11/julian-assange-arrested-at-ecuadorian-embassy-wikileaks")
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Aws 'Comprehend' allows up to 5000 chars per request.
This change makes an async request per chunk and concatenates the results using [WaitGroup](https://golang.org/pkg/sync/#WaitGroup)

- [x] Avoid splitting on words
- [ ] Fix the offsets (currently they're relative to the chunk, not the whole bodyText)